### PR TITLE
(Proposal) Ditch DatePeriod

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -69,7 +69,7 @@ class CarbonPeriod implements Iterator
     public function __construct()
     {
         $arguments = func_get_args();
-        $reflection = new ReflectionClass('DatePeriod');
+        $reflection = new ReflectionClass('DatePeriod'); // Ditch me?
         if (count($arguments) > 1) {
             if (self::isDate($arguments[0]) && !$arguments[1] instanceof DateInterval) {
                 array_splice($arguments, 1, 0, array(CarbonInterval::day()));


### PR DESCRIPTION
Relying on `DatePeriod` seems to be just cluttering constructor without bringing any benefits.

- Our iterator can simply use `$this->current->add($this->interval)`
- Parsing `An ISO 8601` format is just matter of `explode('/', $format)`?
- Separate constructors will be easier to maintain:
```php
static create($startDateOrString, $intervalOrString, $endDateOrStringOrRecurrences)
static createFromISO($format)
static between($startDateOrString, $endDateOrString, $intervalOrString = null) // from now to date
static since($startDateOrString, $intervalOrString = null) // from date to now
static until($endDateOrString, $intervalOrString = null) // from now to date
static last($recurrences, $intervalOrString = null) // x recurrences of interval to now
static next($recurrences, $intervalOrString = null) // x recurrences of interval from now
__construct($startDate, $interval, $endDateOrRecurrences) // by default start inclusive end exclusive
```
- We will be able to ensure that number of recurrences will be returned no matter the filters (wonder what happens when filters are mutually exclusive... infinite loop I guess?)
- We will be able to specify number of recurrences, start and end date no matter the input (will be time expensive, as we need to go through whole thing with filters to calculate that)

Just a proposal without any actual code so you can let me know your opinion on this.