### PR TITLE
Allow to call modify/parse string as a fluent method

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ parameters:
 		- '*/tests/Carbon/MacroTest.php'
 		- '*/tests/Carbon/SettersTest.php'
 		- '*/tests/Carbon/GettersTest.php'
+		- '*/tests/Carbon/FluidSettersTest.php'
 		- '*/tests/Carbon/IsTest.php'
 		- '*/tests/Carbon/StrictModeTest.php'
 		- '*/tests/Carbon/Fixtures/Mixin.php'

--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -669,6 +669,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
 
     public function isLastOfMonth();
 
+    public function isLastDayOfMonth();
+
     public function isStartOfDay($checkMicroseconds);
 
     public function isEndOfDay($checkMicroseconds);

--- a/tests/Carbon/ConstructTest.php
+++ b/tests/Carbon/ConstructTest.php
@@ -120,4 +120,12 @@ class ConstructTest extends AbstractTestCase
 
         Carbon::setTestNow();
     }
+
+    public function testFluentCreate()
+    {
+        $date = Carbon::lastDayOfPreviousMonth();
+        $this->assertInstanceOfCarbon($date);
+        $this->assertTrue($date->isLastMonth());
+        $this->assertTrue($date->isLastDayOfMonth());
+    }
 }

--- a/tests/Carbon/FluidSettersTest.php
+++ b/tests/Carbon/FluidSettersTest.php
@@ -120,4 +120,12 @@ class FluidSettersTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($d->timestamp(10));
         $this->assertSame(10, $d->timestamp);
     }
+
+    public function testFluentCreate()
+    {
+        $date = Carbon::now()->lastDayOfPreviousMonth();
+        $this->assertInstanceOfCarbon($date);
+        $this->assertTrue($date->isLastMonth());
+        $this->assertTrue($date->isLastDayOfMonth());
+    }
 }


### PR DESCRIPTION
This would allow to pass any relative date/time string as a method:

```php
Carbon::lastDayOfPreviousMonth() // Carbon::parse('last day of previous month')
Carbon::firstDayOfDecember2018() // Carbon::parse('first day of december 2018')
Carbon::parse('2018-06-13')->nextSunday() // Carbon::parse('2018-06-13')->modify('next sunday')
```